### PR TITLE
Solved the connexion cookie issue

### DIFF
--- a/icc-api/api/XHR.ts
+++ b/icc-api/api/XHR.ts
@@ -64,6 +64,7 @@ export namespace XHR {
   ): Promise<Data> {
     return new Promise<Data>(function(resolve, reject) {
       var jsXHR = new XMLHttpRequest()
+	  jsXHR.withCredentials = true;
       jsXHR.open(method, url)
       const contentType = headers && headers.find(it => it.header === "Content-Type")
       if (headers != null) {


### PR DESCRIPTION
Adding the credentials to the XHR solved the problem.

But, as Jurgen Van de Moere said "[...] we should be careful with this option because I think it will also send to cookie to any third party we may send an XHR request to (if any)."