### PR TITLE
AES error handling

### DIFF
--- a/icc-x-api/icc-contact-x-api.ts
+++ b/icc-x-api/icc-contact-x-api.ts
@@ -369,7 +369,7 @@ export class IccContactXApi extends iccContactApi {
               )
               .then((sfks: Array<string>) => {
                 if (!sfks || !sfks.length) {
-                  //console.log("Cannot decrypt contact", ctc.id)
+                  console.log("Cannot decrypt contact", ctc.id)
                   return Promise.resolve(ctc)
                 }
                 return Promise.all(

--- a/icc-x-api/icc-helement-x-api.ts
+++ b/icc-x-api/icc-helement-x-api.ts
@@ -183,7 +183,7 @@ export class IccHelementXApi extends iccHelementApi {
                               resolve(he)
                             },
                             () => {
-                              console.log("Cannot decrypt contact", he.id)
+                              console.log("Cannot decrypt helement", he.id)
                               resolve(he)
                             }
                           )


### PR DESCRIPTION
If the encryptionKeys of a contact or health element turns out to be undecryptable, the decryption promise of a set of objects fails altogether (because one of the promises in Promise.all is rejected). This has been observed in production.

Handling the AES decryption error upstream makes the contact and health element decryption failure handled properly.