### PR TITLE
discard undecryptable hcpartykeys

### DIFF
--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -126,8 +126,17 @@ export class IccCryptoXApi {
       // For each delegatorId, obtain the AES keys
       return Promise.all(
         delegatorsHcPartyIdsSet.map((delegatorId: string) =>
-          this.decryptHcPartyKey(delegatorId, delegateHcPartyId, healthcarePartyKeys[delegatorId])
+          this.decryptHcPartyKey(
+            delegatorId,
+            delegateHcPartyId,
+            healthcarePartyKeys[delegatorId]
+          ).catch(() => {
+            console.log(`failed to decrypt hcPartyKey from ${delegatorId} to ${delegateHcPartyId}`)
+            return undefined
+          })
         )
+      ).then(hcPartyKeys =>
+        hcPartyKeys.filter(<T>(hcPartyKey: T | undefined): hcPartyKey is T => !!hcPartyKey)
       )
     })
   }


### PR DESCRIPTION
The catch is not run most of the time, but this makes delegation decryption more robust in case of database issues. For example, if the hcPartyKeys of a HCP does not agree with the delegate's RSA key but the parent HCP can decrypt his own hcPartyKey, the decryption can fall back to that key.

I would have liked to keep the info that the key is not decryptable in the `IccCryptoXApi` instance's `hcPartyKeysCache`, but that would imply changing the type of the `key` property in the cache entries, which could have negative consequences over other parts of the code. Not all uses of the cache benefit from static type checking (when `any` type assertions are used).