### PR TITLE
Remove obsolete util functions

### DIFF
--- a/icc-x-api/utils/hcp-util.ts
+++ b/icc-x-api/utils/hcp-util.ts
@@ -83,26 +83,6 @@ export const SPECIALITIES_KEYS: { [spec: string]: string } = _.fromPairs(
   SPECIALITIES.map(spec => [spec, "hcp-form.SPECIALITIES." + spec])
 )
 
-export function isDoctor(nihii: string): boolean {
-  return (
-    !!nihii &&
-    nihii.length === 11 &&
-    nihii.startsWith("1") &&
-    !nihii.endsWith("005") &&
-    !nihii.endsWith("006")
-  )
-}
-
-export function isDoctorAssistant(nihii: string): boolean {
-  return (
-    !!nihii &&
-    nihii.length === 11 &&
-    nihii.startsWith("1") &&
-    nihii.endsWith("005") &&
-    nihii.endsWith("006")
-  )
-}
-
 export function getPhoneNumber(
   hcp: HealthcarePartyDto,
   maxLength: number | undefined


### PR DESCRIPTION
Those two functions are unused and their logic has changed in MS.

@aduchate Many utility functions that were copied from MS into `icc-x-api/utils` in 9a37d99d178c5a3545b73c56318ba441611d16ef are not used at all. It would be good to clean them up.