### PR TITLE
B12/fix/hcpartykey init conflict

### DIFF
--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -472,37 +472,24 @@ export class IccCryptoXApi {
     secretDelegationKey: string,
     secretEncryptionKey: string
   ) {
-    return Promise.all([
-      this.extendedDelegationsAndCryptedForeignKeys(
-        child,
-        parent,
-        ownerId,
-        delegateId,
-        secretDelegationKey
-      ),
-      this.appendEncryptionKeys(child, ownerId, delegateId, secretEncryptionKey)
-    ]).then(extraData => {
-      const extraDels = extraData[0]
-      const extraEks = extraData[1]
-      return _.assign(child, {
-        // Conservative version ... We might want to be more aggressive with the deduplication of keys
-        // For each delegate, we are going to concatenate to the src (the new delegations), the object in dest (the current delegations)
-        // for which we do not find an equivalent delegation (same delegator, same delegate)
-        delegations: _.assignWith(child.delegations, extraDels.delegations, (dest, src) =>
-          (src || []).concat(
-            _.filter(
-              dest,
-              (d: DelegationDto) =>
-                !src.some(
-                  (s: DelegationDto) => s.owner === d.owner && s.delegatedTo === d.delegatedTo
-                )
-            )
-          )
-        ),
-        cryptedForeignKeys: _.assignWith(
-          child.cryptedForeignKeys,
-          extraDels.cryptedForeignKeys,
-          (dest, src) =>
+    return this.extendedDelegationsAndCryptedForeignKeys(
+      child,
+      parent,
+      ownerId,
+      delegateId,
+      secretDelegationKey
+    )
+      .then(extraDels =>
+        this.appendEncryptionKeys(child, ownerId, delegateId, secretEncryptionKey).then(
+          extraEks => ({ extraDels, extraEks })
+        )
+      )
+      .then(({ extraDels, extraEks }) => {
+        return _.assign(child, {
+          // Conservative version ... We might want to be more aggressive with the deduplication of keys
+          // For each delegate, we are going to concatenate to the src (the new delegations), the object in dest (the current delegations)
+          // for which we do not find an equivalent delegation (same delegator, same delegate)
+          delegations: _.assignWith(child.delegations, extraDels.delegations, (dest, src) =>
             (src || []).concat(
               _.filter(
                 dest,
@@ -512,20 +499,34 @@ export class IccCryptoXApi {
                   )
               )
             )
-        ),
-        encryptionKeys: _.assignWith(child.encryptionKeys, extraEks.encryptionKeys, (dest, src) =>
-          (src || []).concat(
-            _.filter(
-              dest,
-              (d: DelegationDto) =>
-                !src.some(
-                  (s: DelegationDto) => s.owner === d.owner && s.delegatedTo === d.delegatedTo
+          ),
+          cryptedForeignKeys: _.assignWith(
+            child.cryptedForeignKeys,
+            extraDels.cryptedForeignKeys,
+            (dest, src) =>
+              (src || []).concat(
+                _.filter(
+                  dest,
+                  (d: DelegationDto) =>
+                    !src.some(
+                      (s: DelegationDto) => s.owner === d.owner && s.delegatedTo === d.delegatedTo
+                    )
                 )
+              )
+          ),
+          encryptionKeys: _.assignWith(child.encryptionKeys, extraEks.encryptionKeys, (dest, src) =>
+            (src || []).concat(
+              _.filter(
+                dest,
+                (d: DelegationDto) =>
+                  !src.some(
+                    (s: DelegationDto) => s.owner === d.owner && s.delegatedTo === d.delegatedTo
+                  )
+              )
             )
           )
-        )
+        })
       })
-    })
   }
 
   /**

--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -853,7 +853,11 @@ export class IccCryptoXApi {
               )
               .then(() =>
                 this.hcpartyBaseApi.modifyHealthcareParty(owner).then(hcp => {
-                  this.emptyHcpCache(hcp.id)
+                  // invalidate the hcp cache for the modified hcp
+                  this.emptyHcpCache(ownerId)
+                  // invalidate the hcPartyKeys cache for the delegate hcp (who was not modified, but the view for its
+                  // id was updated)
+                  this.emptyHcpCache(delegateId)
                   return hcp
                 })
               )

--- a/icc-x-api/icc-hcparty-x-api.ts
+++ b/icc-x-api/icc-hcparty-x-api.ts
@@ -19,15 +19,15 @@ export class IccHcpartyXApi extends iccHcpartyApi {
       .modifyHealthcareParty(body)
       .then(
         hcp =>
-          (this.cache[hcp.id] = [+Date() + this.CACHE_RETENTION_IN_MS, Promise.resolve(hcp)])[1]
+          (this.cache[hcp.id] = [Date.now() + this.CACHE_RETENTION_IN_MS, Promise.resolve(hcp)])[1]
       )
   }
 
   getHealthcareParty(healthcarePartyId: string): Promise<HealthcarePartyDto | any> {
     const fromCache = this.cache[healthcarePartyId]
-    return !fromCache || +Date() > fromCache[0]
+    return !fromCache || Date.now() > fromCache[0]
       ? (this.cache[healthcarePartyId] = [
-          +Date() + this.CACHE_RETENTION_IN_MS,
+          Date.now() + this.CACHE_RETENTION_IN_MS,
           super.getHealthcareParty(healthcarePartyId).catch(e => {
             delete this.cache[healthcarePartyId]
             throw e
@@ -40,7 +40,7 @@ export class IccHcpartyXApi extends iccHcpartyApi {
     const ids = healthcarePartyIds.split(",")
     const cached = ids.map(x => {
       const c = this.cache[x]
-      return c && c[0] > +Date() ? c : null
+      return c && c[0] > Date.now() ? c : null
     })
     const toFetch = ids.map((id, idx) => !cached[idx] && id)
 
@@ -54,7 +54,7 @@ export class IccHcpartyXApi extends iccHcpartyApi {
                   cached[idx]
                     ? cached[idx]![1]
                     : (this.cache[id] = [
-                        +Date() + this.CACHE_RETENTION_IN_MS,
+                        Date.now() + this.CACHE_RETENTION_IN_MS,
                         Promise.resolve(hcps.find(h => h.id === id)!)
                       ])[1]
               )
@@ -65,7 +65,7 @@ export class IccHcpartyXApi extends iccHcpartyApi {
 
   getCurrentHealthcareParty(): Promise<HealthcarePartyDto | any> {
     return super.getCurrentHealthcareParty().then(hcp => {
-      this.cache[hcp.id] = [+Date() + this.CACHE_RETENTION_IN_MS, Promise.resolve(hcp)]
+      this.cache[hcp.id] = [Date.now() + this.CACHE_RETENTION_IN_MS, Promise.resolve(hcp)]
       return hcp
     })
   }


### PR DESCRIPTION
This PR resolves three issues:

### AES key generation race and HCP update conflict
When initializing the delegations of a contact (in `IccContactXApi.newInstance`) with a healthcare party that has no hcPartyKey for the delegate, the crypto-x-api attempts to create AES keys in two simultaneous promises.

This results in two different generated keys and two concurrent submissions to the backend, with one of the two failing because of a db conflict.

### hcPartyKeys cache invalidation
After generating hcPartyKeys, the cache that keeps a copy of the hcPartyKeys for the delegate (`IccCryptoXApi.hcPartyKeysRequestsCache`) is not invalidated, so the crypto api is not ready to decrypt the delegations it just encrypted, until the cache is emptied by reloading the app.

### hcparty cache timestamps are systematically `NaN`
The timestamp calculations for the `IccHcpartyXApi` `cache` used `+Date()` (which converts a string such as `"Tue Feb 05 2019 10:43:50 GMT+0100 (Central European Standard Time)"` into `NaN`) instead of `Date.now()` to get a timestamp in milliseconds. The `NaN`-`NaN` comparisons (which always return `false`), depending on how the comparison was made, meant that the retention time was either effectively 0 or infinite.