### PR TITLE
B12/efact month year fix to prevent duplicate batch numseq

### DIFF
--- a/icc-x-api/utils/efact-util.ts
+++ b/icc-x-api/utils/efact-util.ts
@@ -195,9 +195,9 @@ export function toInvoiceBatch(
             )
 
             const now = new Date()
-            const invoicingMonth =
-              toMoment(invoicesWithPatient[0].invoiceDto.invoiceDate!!)!!.month() + 1
-            const invoicingYear = toMoment(invoicesWithPatient[0].invoiceDto.invoiceDate!!)!!.year()
+            const invoiceDate = toMoment(invoicesWithPatient[0].invoiceDto.invoiceDate!!)
+            const invoicingMonth = invoiceDate!!.month() + 1
+            const invoicingYear = invoiceDate!!.year()
 
             // The OA 500, matches the monthYear (zone 300) to check the batch sending number
             // Use sending year to prevent duplicate sending number in case of invoices made

--- a/icc-x-api/utils/efact-util.ts
+++ b/icc-x-api/utils/efact-util.ts
@@ -193,11 +193,23 @@ export function toInvoiceBatch(
                 )
               }
             )
-            invoicesBatch.invoicingMonth =
+
+            const now = new Date()
+            const invoicingMonth =
               toMoment(invoicesWithPatient[0].invoiceDto.invoiceDate!!)!!.month() + 1
-            invoicesBatch.invoicingYear = toMoment(
-              invoicesWithPatient[0].invoiceDto.invoiceDate!!
-            )!!.year()
+            const invoicingYear = toMoment(invoicesWithPatient[0].invoiceDto.invoiceDate!!)!!.year()
+
+            // The OA 500, matches the monthYear (zone 300) to check the batch sending number
+            // Use sending year to prevent duplicate sending number in case of invoices made
+            // on the previous year
+            if (now.getFullYear() === invoicingYear) {
+              invoicesBatch.invoicingMonth = invoicingMonth
+              invoicesBatch.invoicingYear = invoicingYear
+            } else {
+              invoicesBatch.invoicingMonth = now.getMonth() + 1
+              invoicesBatch.invoicingYear = now.getFullYear()
+            }
+
             invoicesBatch.ioFederationCode = fedCodes[0]
             invoicesBatch.numericalRef =
               moment().get("year") * 1000000 + Number(fedCodes[0]) * 1000 + batchNumber


### PR DESCRIPTION
The OA 500 takes into account the monthYear (Zone 300) to determine the accounting  year for numseq checking.

In case of invoices from 2018 sent in 2019, this yearMonth is 201812 causing issue with duplicate numseq.