### PR TITLE
Efact message 920000 generation fix

### DIFF
--- a/icc-x-api/icc-message-x-api.ts
+++ b/icc-x-api/icc-message-x-api.ts
@@ -1131,8 +1131,8 @@ export class IccMessageXApi extends iccMessageApi {
                         metas: {
                           ioFederationCode: batch.ioFederationCode,
                           numericalRef: batch.numericalRef,
-                          invoiceMonth: batch.invoicingMonth,
-                          invoiceYear: batch.invoicingYear,
+                          invoiceMonth: _.padStart("" + batch.invoicingMonth, 2, "0"),
+                          invoiceYear: _.padStart("" + batch.invoicingYear, 4, "0"),
                           totalAmount: totalAmount,
                           fhc_server: fhcServer,
                           errors: res.error

--- a/icc-x-api/utils/efact-util.ts
+++ b/icc-x-api/utils/efact-util.ts
@@ -24,7 +24,8 @@ export interface RelatedInvoiceInfo {
   invoiceReference?: string
   sendNumber?: string
   insuranceCode?: string
-  invoicingYearMonth?: string
+  invoicingYear?: string
+  invoicingMonth?: string
 }
 
 export interface InvoiceWithPatient {
@@ -125,7 +126,8 @@ export function getRelatedInvoicesInfo(
               insuranceCode: insurance.code,
               invoiceReference: relatedInvoice.invoiceReference,
               sendNumber: message.externalRef,
-              invoicingYearMonth: message.metas!!.invoiceYear + message.metas!!.invoiceMonth
+              invoicingYear: _.padStart(message.metas!!.invoiceYear, 4, "0"),
+              invoicingMonth: _.padStart(message.metas!!.invoiceMonth, 2, "0")
             })
           })
 
@@ -252,8 +254,12 @@ function toInvoice(
 
   if (relatedInvoiceInfo) {
     invoice.relatedBatchSendNumber = Number(relatedInvoiceInfo.sendNumber)
-    invoice.relatedBatchYearMonth = Number(relatedInvoiceInfo.invoicingYearMonth)
-    invoice.relatedInvoiceNumber = Number(relatedInvoiceInfo.invoiceReference)
+    invoice.relatedBatchYearMonth = Number(
+      relatedInvoiceInfo.invoicingYear!! + relatedInvoiceInfo.invoicingMonth
+    )
+    invoice.relatedInvoiceNumber = Number(
+      relatedInvoiceInfo.invoicingYear!! + relatedInvoiceInfo.invoiceReference
+    )
     invoice.relatedInvoiceIoCode = relatedInvoiceInfo.insuranceCode
   }
 


### PR DESCRIPTION
**Before correction**
- The invoice reference of the previous batch ET20 Z29 doesn't contain the year (e.g. "000000000243") !
- MonthYear of the previous invoice not correct ET20 Z40 (e.g. "020192") if the month is between January and September => Need to add a padding 

**After correction**
- The invoice reference of the previous batch ET20 Z29 has the same format at the ET20 Z24 (e.g. "002019000243")
- MonthYear of the previous invoice correctly formatted ET20 Z40 (e.g. "201902")