### PR TITLE
eFact message match fix - URGENT

### DIFF
--- a/icc-x-api/icc-message-x-api.ts
+++ b/icc-x-api/icc-message-x-api.ts
@@ -715,9 +715,9 @@ export class IccMessageXApi extends iccMessageApi {
       }
 
       // Find message for Hcp based on the invoiceReference if present (!931000)
-      const fileReference = _.get(parsedRecords, "zone300.invoiceReference")
+      const fileReference = _.get(parsedRecords, "et10.invoiceReference")
       const parentMessage = fileReference
-        ? _.find(msgsForHcp, m => uuidBase36Half(m.id!!) === fileReference.trim())
+        ? _.find(msgsForHcp, m => uuidBase36(m.id!!) === fileReference.trim())
         : msgsForHcp[0]
 
       if (!parentMessage) {


### PR DESCRIPTION
When the user manage to send several batches with the same reference (eg 2019500001), there could be an issue when receiving the answers (sending from non sync system, ...)

Indeed, the messages are get from the transportGUID, and when several messages have the same reference, the system take the first one.

A first fix has been released to fix the problem but all OAs do not behave the same way. A new fix is needed => Use the file reference of the ET10 instead of the file reference of the zone 300