### PR TITLE
[MS-115] Check if we try to send invoices directly to the federations

### DIFF
--- a/icc-x-api/utils/efact-util.ts
+++ b/icc-x-api/utils/efact-util.ts
@@ -47,6 +47,19 @@ export function getFederaton(
       })
     )
     .then((insurances: Array<InsuranceDto>) => {
+      // We will check here for recipient which are federations (except 306).
+
+      const federations = insurances.filter(i => i.code !== "306" && i.id === i.parent)
+
+      if (federations.length > 0) {
+        console.error(
+          `Invoices directed to ${federations.map(i => i.code).join()}, invoices ${invoices.map(
+            i => i.invoiceDto.id
+          )}`
+        )
+        throw "Some invoices are directly destinated to federations inside of mutuality office !"
+      }
+
       return insuranceApi
         .getInsurances(new ListOfIdsDto({ ids: _.uniq(_.compact(insurances.map(i => i.parent))) }))
         .then((parents: Array<InsuranceDto>) => {
@@ -155,6 +168,19 @@ export function toInvoiceBatch(
       })
     )
     .then((insurances: Array<InsuranceDto>) => {
+      // We will check here for recipient which are federations (except 306).
+
+      const federations = insurances.filter(i => i.code !== "306" && i.id === i.parent)
+
+      if (federations.length > 0) {
+        console.error(
+          `Invoices directed to ${federations
+            .map(i => i.code)
+            .join()}, invoices ${invoicesWithPatient.map(i => i.invoiceDto.id)}`
+        )
+        throw "Some invoices are directly destinated to federations instead of mutuality !"
+      }
+
       return insuranceApi
         .getInsurances(new ListOfIdsDto({ ids: _.uniq(_.compact(insurances.map(i => i.parent))) }))
         .then((parents: Array<InsuranceDto>) => {

--- a/icc-x-api/utils/efact-util.ts
+++ b/icc-x-api/utils/efact-util.ts
@@ -5,7 +5,8 @@ import {
   InvoicingCodeDto,
   ListOfIdsDto,
   PatientDto,
-  MessageDto
+  MessageDto,
+  InsurabilityDto
 } from "../../icc-api/model/models"
 import { IccInvoiceXApi, IccMessageXApi } from "../../icc-x-api"
 import { iccInsuranceApi } from "../../icc-api/api/iccInsuranceApi"
@@ -36,6 +37,21 @@ export interface InvoiceWithPatient {
 
 const base36UUID = new UuidEncoder()
 
+function ensureNoFederation(invoices: Array<InvoiceWithPatient>, insurances: Array<InsuranceDto>) {
+  // We will check here for recipient which are federations (except 306).
+
+  const federations = insurances.filter(i => i.code !== "306" && i.id === i.parent)
+
+  if (federations.length > 0) {
+    console.error(
+      `Invoices directed to ${federations.map(i => i.code).join()}, invoices ${invoices.map(
+        i => i.invoiceDto.id
+      )}`
+    )
+    throw "Some invoices are directly destinated to federations inside of mutuality office !"
+  }
+}
+
 export function getFederaton(
   invoices: Array<InvoiceWithPatient>,
   insuranceApi: iccInsuranceApi
@@ -47,18 +63,7 @@ export function getFederaton(
       })
     )
     .then((insurances: Array<InsuranceDto>) => {
-      // We will check here for recipient which are federations (except 306).
-
-      const federations = insurances.filter(i => i.code !== "306" && i.id === i.parent)
-
-      if (federations.length > 0) {
-        console.error(
-          `Invoices directed to ${federations.map(i => i.code).join()}, invoices ${invoices.map(
-            i => i.invoiceDto.id
-          )}`
-        )
-        throw "Some invoices are directly destinated to federations inside of mutuality office !"
-      }
+      ensureNoFederation(invoices, insurances)
 
       return insuranceApi
         .getInsurances(new ListOfIdsDto({ ids: _.uniq(_.compact(insurances.map(i => i.parent))) }))
@@ -168,18 +173,7 @@ export function toInvoiceBatch(
       })
     )
     .then((insurances: Array<InsuranceDto>) => {
-      // We will check here for recipient which are federations (except 306).
-
-      const federations = insurances.filter(i => i.code !== "306" && i.id === i.parent)
-
-      if (federations.length > 0) {
-        console.error(
-          `Invoices directed to ${federations
-            .map(i => i.code)
-            .join()}, invoices ${invoicesWithPatient.map(i => i.invoiceDto.id)}`
-        )
-        throw "Some invoices are directly destinated to federations instead of mutuality !"
-      }
+      ensureNoFederation(invoicesWithPatient, insurances)
 
       return insuranceApi
         .getInsurances(new ListOfIdsDto({ ids: _.uniq(_.compact(insurances.map(i => i.parent))) }))


### PR DESCRIPTION
Some doctors had issues when trying to send eFact because they were sending it directly to the federation instead of the mutuality (like trying to send to the 300 instead of the 317).

We now checks if the recepient of the eFacts are mutualities and not federations !